### PR TITLE
fix(config): chat height have a reasonable limit

### DIFF
--- a/src/main/kotlin/cc/woverflow/chatting/config/ChattingConfig.kt
+++ b/src/main/kotlin/cc/woverflow/chatting/config/ChattingConfig.kt
@@ -89,7 +89,7 @@ object ChattingConfig :
     @Property(
         type = PropertyType.SLIDER,
         min = 180,
-        max = 10000,
+        max = 2160,
         name = "Focused Height",
         description = "Height in pixels.",
         category = "Chat Window"
@@ -99,7 +99,7 @@ object ChattingConfig :
     @Property(
         type = PropertyType.SLIDER,
         min = 180,
-        max = 10000,
+        max = 2160,
         name = "Unfocused Height",
         description = "Height in pixels.",
         category = "Chat Window"


### PR DESCRIPTION
## Description
Makes it so the chat height can only go up to 2,160. 10,000 is super unreasonable and makes it harder to get a precise number. It would be best if you could just type in the number.