### PR TITLE
Add hover only timestamp

### DIFF
--- a/src/main/java/org/polyfrost/chatting/hook/ChatLineHook.java
+++ b/src/main/java/org/polyfrost/chatting/hook/ChatLineHook.java
@@ -5,11 +5,15 @@ import net.minecraft.client.network.NetworkPlayerInfo;
 
 import java.lang.ref.WeakReference;
 import java.util.HashSet;
+import java.util.List;
 
 public interface ChatLineHook {
     HashSet<WeakReference<ChatLine>> chatLines = new HashSet<>();
     boolean isDetected();
     void setDetected(boolean detected);
+    List<ChatLine> getChildren();
+    long getTimestamp();
+    void setTimestamp(long timestamp);
     NetworkPlayerInfo getPlayerInfo();
     void setPlayerInfo(NetworkPlayerInfo playerInfo);
     NetworkPlayerInfo getDetectedPlayerInfo();

--- a/src/main/java/org/polyfrost/chatting/mixin/ChatLineMixin.java
+++ b/src/main/java/org/polyfrost/chatting/mixin/ChatLineMixin.java
@@ -17,6 +17,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
 
 @Mixin(ChatLine.class)
 public class ChatLineMixin implements ChatLineHook {
@@ -26,6 +28,23 @@ public class ChatLineMixin implements ChatLineHook {
     private NetworkPlayerInfo detectedPlayerInfo;
     private static long lastUniqueId = 0;
     private long uniqueId = 0;
+    private long timestamp;
+    private List<ChatLine> children = new ArrayList<>();
+
+    @Override
+    public List<ChatLine> getChildren() {
+        return children;
+    }
+
+    @Override
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
 
     @Inject(method = "<init>", at = @At("RETURN"))
     private void onInit(int i, IChatComponent iChatComponent, int j, CallbackInfo ci) {

--- a/src/main/java/org/polyfrost/chatting/mixin/GuiChatMixin.java
+++ b/src/main/java/org/polyfrost/chatting/mixin/GuiChatMixin.java
@@ -2,13 +2,6 @@ package org.polyfrost.chatting.mixin;
 
 import cc.polyfrost.oneconfig.libs.universal.UDesktop;
 import cc.polyfrost.oneconfig.libs.universal.UResolution;
-import org.polyfrost.chatting.chat.*;
-import org.polyfrost.chatting.config.ChattingConfig;
-import org.polyfrost.chatting.gui.components.ClearButton;
-import org.polyfrost.chatting.gui.components.ScreenshotButton;
-import org.polyfrost.chatting.gui.components.SearchButton;
-import org.polyfrost.chatting.hook.ChatLineHook;
-import org.polyfrost.chatting.hook.GuiNewChatHook;
 import com.google.common.collect.Lists;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ChatLine;
@@ -19,8 +12,13 @@ import net.minecraft.util.MathHelper;
 import net.minecraftforge.fml.client.config.GuiUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.lwjgl.input.Mouse;
-import org.polyfrost.chatting.chat.ChatSearchingManager;
-import org.polyfrost.chatting.chat.ChatShortcuts;
+import org.polyfrost.chatting.chat.*;
+import org.polyfrost.chatting.config.ChattingConfig;
+import org.polyfrost.chatting.gui.components.ClearButton;
+import org.polyfrost.chatting.gui.components.ScreenshotButton;
+import org.polyfrost.chatting.gui.components.SearchButton;
+import org.polyfrost.chatting.hook.ChatLineHook;
+import org.polyfrost.chatting.hook.GuiNewChatHook;
 import org.polyfrost.chatting.utils.ModCompatHooks;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -72,6 +70,11 @@ public abstract class GuiChatMixin extends GuiScreen {
         }
     }
 
+    @Inject(method = "onGuiClosed", at = @At("HEAD"))
+    private void onGuiClosedHook(CallbackInfo ci) {
+        ModCompatHooks.setHoveredText(null);
+    }
+
     @Inject(method = "updateScreen", at = @At("HEAD"))
     private void updateScreen(CallbackInfo ci) {
         if (ChattingConfig.INSTANCE.getChatSearch() && searchButton.isEnabled()) {
@@ -95,6 +98,8 @@ public abstract class GuiChatMixin extends GuiScreen {
     @Inject(method = "drawScreen", at = @At("HEAD"))
     private void onDrawScreen(int mouseX, int mouseY, float partialTicks, CallbackInfo ci) {
         GuiNewChatHook hook = ((GuiNewChatHook) Minecraft.getMinecraft().ingameGUI.getChatGUI());
+        ChatLine hoveredLine = hook.getHoveredLine(Mouse.getY());
+        ModCompatHooks.setHoveredText(hoveredLine);
         float f = mc.ingameGUI.getChatGUI().getChatScale();
         int x = MathHelper.floor_float((float) mouseX / f);
         if (hook.isHovering() && (hook.getRight() + ModCompatHooks.getXOffset() + 3) <= x && (hook.getRight() + ModCompatHooks.getXOffset()) + 13 > x) {

--- a/src/main/java/org/polyfrost/chatting/mixin/GuiNewChatMapMixin.java
+++ b/src/main/java/org/polyfrost/chatting/mixin/GuiNewChatMapMixin.java
@@ -3,6 +3,7 @@ package org.polyfrost.chatting.mixin;
 import net.minecraft.client.gui.ChatLine;
 import net.minecraft.client.gui.GuiNewChat;
 import net.minecraft.util.IChatComponent;
+import org.polyfrost.chatting.hook.ChatLineHook;
 import org.polyfrost.chatting.hook.GuiNewChatHook;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -12,6 +13,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import tv.twitch.chat.Chat;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -50,6 +52,9 @@ public abstract class GuiNewChatMapMixin implements GuiNewChatHook {
     private void handleLineAdded(IChatComponent chatComponent, int chatLineId, int updateCounter, boolean displayOnly, CallbackInfo ci) {
         if (!displayOnly) {
             ChatLine masterLine = chatLines.get(0);
+            ChatLineHook masterHook = (ChatLineHook) masterLine;
+            masterHook.setTimestamp(System.currentTimeMillis());
+            masterHook.getChildren().addAll(tempDrawnLines);
             for (ChatLine tempDrawnLine : tempDrawnLines) drawnToFull.put(tempDrawnLine, masterLine);
         }else {
             lastTempLine = null;

--- a/src/main/java/org/polyfrost/chatting/mixin/GuiUtilRenderComponentsMixin.java
+++ b/src/main/java/org/polyfrost/chatting/mixin/GuiUtilRenderComponentsMixin.java
@@ -14,6 +14,7 @@ public class GuiUtilRenderComponentsMixin {
         if (ChattingConfig.INSTANCE.getShowChatHeads() && (ChattingConfig.INSTANCE.getOffsetNonPlayerMessages() || ChatHeadHooks.INSTANCE.detect(text, null))) {
             return fontRenderer.getStringWidth(text) + 10;
         }
+        // TODO: time thingy?
         return fontRenderer.getStringWidth(text);
     }
 }

--- a/src/main/kotlin/org/polyfrost/chatting/config/ChattingConfig.kt
+++ b/src/main/kotlin/org/polyfrost/chatting/config/ChattingConfig.kt
@@ -136,24 +136,19 @@ object ChattingConfig : Config(
     )
     var hideChatHeadOnConsecutiveMessages = true
 
-    /*/
-    @Property(
-        type = PropertyType.SWITCH,
+    @Switch(
         name = "Show Timestamp",
         description = "Show message timestamp.",
         category = "General"
     )
     var showTimestamp = false
 
-    @Property(
-        type = PropertyType.SWITCH,
+    @Switch(
         name = "Timestamp Only On Hover",
         description = "Show timestamp only on mouse hover.",
         category = "General"
     )
     var showTimestampHover = true
-
-     */
 
     @Info(
         text = "If Chatting detects a public chat message that seems like spam, and the probability is higher than this, it will hide it.\n" + "Made for Hypixel Skyblock. Set to 100% to disable. 95% is a reasonable threshold to use it at.\n" + "Note that this is not and never will be 100% accurate; however, it's pretty much guaranteed to block most spam.",

--- a/src/main/kotlin/org/polyfrost/chatting/utils/ModCompatHooks.kt
+++ b/src/main/kotlin/org/polyfrost/chatting/utils/ModCompatHooks.kt
@@ -3,11 +3,6 @@ package org.polyfrost.chatting.utils
 import cc.polyfrost.oneconfig.renderer.TextRenderer
 import cc.polyfrost.oneconfig.utils.dsl.getAlpha
 import cc.polyfrost.oneconfig.utils.dsl.mc
-import org.polyfrost.chatting.Chatting.isBetterChat
-import org.polyfrost.chatting.Chatting.isPatcher
-import org.polyfrost.chatting.config.ChattingConfig.offsetNonPlayerMessages
-import org.polyfrost.chatting.config.ChattingConfig.showChatHeads
-import org.polyfrost.chatting.config.ChattingConfig.textRenderType
 import club.sk1er.patcher.config.PatcherConfig
 import com.llamalad7.betterchat.BetterChat
 import net.minecraft.client.Minecraft
@@ -15,9 +10,18 @@ import net.minecraft.client.gui.ChatLine
 import net.minecraft.client.gui.FontRenderer
 import net.minecraft.client.gui.Gui
 import net.minecraft.client.renderer.GlStateManager
+import org.polyfrost.chatting.Chatting.isBetterChat
+import org.polyfrost.chatting.Chatting.isPatcher
+import org.polyfrost.chatting.config.ChattingConfig.offsetNonPlayerMessages
+import org.polyfrost.chatting.config.ChattingConfig.showChatHeads
+import org.polyfrost.chatting.config.ChattingConfig.showTimestamp
+import org.polyfrost.chatting.config.ChattingConfig.textRenderType
 import org.polyfrost.chatting.hook.ChatLineHook
 import org.polyfrost.chatting.hook.GuiNewChatHook
 import org.polyfrost.chatting.mixin.GuiNewChatAccessor
+import java.text.SimpleDateFormat
+import java.util.*
+import kotlin.math.pow
 
 // This exists because mixin doesn't like dummy classes
 object ModCompatHooks {
@@ -54,10 +58,43 @@ object ModCompatHooks {
         get() = (Minecraft.getMinecraft().ingameGUI.chatGUI as GuiNewChatAccessor).drawnChatLines
 
     @JvmStatic
+    fun getFullMessage(chatLine: ChatLine): ChatLine? {
+        return (Minecraft.getMinecraft().ingameGUI.chatGUI as GuiNewChatHook).getFullMessage(chatLine)
+    }
+
+    private var hoveredText: ChatLine? = null
+    private var hoverProgress = 0L
+    private val formatter = SimpleDateFormat("HH:mm")
+
+    fun getTimeStampText(comp: ChatLine): String {
+        comp as ChatLineHook
+        return "[${formatter.format(Date(comp.timestamp))}] "
+    }
+
+    @JvmStatic
+    fun setHoveredText(comp: ChatLine?) {
+        val newComp = comp?.let(::getFullMessage)
+        if (hoveredText != newComp) {
+            hoveredText = newComp
+            hoverProgress = System.currentTimeMillis()
+        }
+    }
+
+    @JvmStatic
     fun redirectDrawString(text: String, x: Float, y: Float, color: Int, chatLine: ChatLine, screenshot: Boolean): Int {
         var actualX = x
+        val hook = chatLine as ChatLineHook
+        if (showTimestamp && !screenshot) {
+            val timeOffsetInfo = getTimeOffset(chatLine)
+            if (timeOffsetInfo != null) {
+                if (timeOffsetInfo.shouldRender) {
+                    fontRenderer.drawString(timeOffsetInfo.text, actualX, y, -1, true)
+                }
+                actualX += timeOffsetInfo.offset
+            }
+        }
         if (showChatHeads && !screenshot) {
-            val hook = chatLine as ChatLineHook
+            val renderX = actualX
             if (hook.isDetected || offsetNonPlayerMessages) {
                 actualX += 10f
             }
@@ -70,7 +107,7 @@ object ModCompatHooks {
                 GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0)
                 GlStateManager.color(1.0f, 1.0f, 1.0f, color.getAlpha() / 255f)
                 Gui.drawScaledCustomSizeModalRect(
-                    (x).toInt(),
+                    (renderX).toInt(),
                     (y - 1f).toInt(),
                     8.0f,
                     8.0f,
@@ -82,7 +119,7 @@ object ModCompatHooks {
                     64.0f
                 )
                 Gui.drawScaledCustomSizeModalRect(
-                    (x).toInt(),
+                    (renderX).toInt(),
                     (y - 1f).toInt(),
                     40.0f,
                     8.0f,
@@ -105,5 +142,36 @@ object ModCompatHooks {
                 (Minecraft.getMinecraft().ingameGUI.chatGUI as GuiNewChatHook).textOpacity)
             else -> fontRenderer.drawString(text, actualX, y, color, true)
         }
+    }
+
+
+    data class TimeOffsetInfo(
+        val text: String,
+        val shouldRender: Boolean,
+        val offset: Int,
+    )
+
+    private fun ease(x: Double): Double {
+        return if (x < 0.5) 4 * x * x * x else 1 - (-2.0 * x + 2).pow(3.0) / 2
+    }
+
+    private fun getTimeOffset(comp: ChatLine): TimeOffsetInfo? {
+        if (!showTimestamp) return null
+        val root = getFullMessage(comp)
+        if (root == null || root != hoveredText) return null
+        if ((root as ChatLineHook).children.firstOrNull() != comp) return null
+        val text = getTimeStampText(root)
+        val strWidth = fontRenderer.getStringWidth(text)
+        val animationTime = ((System.currentTimeMillis() - hoverProgress) / 100.0).coerceIn(0.0, 1.0)
+        val easedAnimationPercentage = ease(animationTime)
+        val progress = (easedAnimationPercentage * strWidth).toInt()
+        return TimeOffsetInfo(text, progress == strWidth, progress)
+    }
+
+    @JvmStatic
+    fun getStartOffset(value: Int, comp: ChatLine): Int {
+        var actualX = value
+        actualX += getTimeOffset(comp)?.offset ?: 0
+        return actualX
     }
 }


### PR DESCRIPTION
## Description
Adds a timestamp that only shows when hovering

## Related Issue(s)


## How to test
<!-- Provide steps to test this PR -->
Go in game, turn on the toggle and hover over chat messages

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
added timestamps to chat that show when hovering over a message
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->