### PR TITLE
add shadow options to chat input box

### DIFF
--- a/src/main/java/org/polyfrost/chatting/hook/GuiTextFieldHook.kt
+++ b/src/main/java/org/polyfrost/chatting/hook/GuiTextFieldHook.kt
@@ -1,0 +1,19 @@
+package org.polyfrost.chatting.hook
+
+import cc.polyfrost.oneconfig.platform.Platform
+import cc.polyfrost.oneconfig.renderer.TextRenderer
+import cc.polyfrost.oneconfig.utils.dsl.getAlpha
+import org.polyfrost.chatting.config.ChattingConfig.chatInput
+import org.polyfrost.chatting.utils.ModCompatHooks
+
+object GuiTextFieldHook {
+    @JvmStatic
+    fun redirectDrawString(text: String, x: Float, y: Float, color: Int): Int {
+        return when (chatInput.inputTextRenderType) {
+            0 -> Platform.getGLPlatform().drawText(text, x, y, color, false).toInt()
+            1 -> Platform.getGLPlatform().drawText(text, x, y, color, true).toInt()
+            2 -> TextRenderer.drawBorderedText(text, x, y, color, color.getAlpha())
+            else -> ModCompatHooks.fontRenderer.drawString(text, x, y, color, true)
+        }
+    }
+}

--- a/src/main/java/org/polyfrost/chatting/mixin/ChatLineMixin.java
+++ b/src/main/java/org/polyfrost/chatting/mixin/ChatLineMixin.java
@@ -23,7 +23,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 @Mixin(ChatLine.class)
 public class ChatLineMixin implements ChatLineHook {

--- a/src/main/java/org/polyfrost/chatting/mixin/GuiIngameForgeMixin.java
+++ b/src/main/java/org/polyfrost/chatting/mixin/GuiIngameForgeMixin.java
@@ -11,7 +11,6 @@ import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
 @Mixin(GuiIngameForge.class)
 public class GuiIngameForgeMixin {
-
     @ModifyArgs(method = "renderChat", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GlStateManager;translate(FFF)V"))
     private void cancelTranslate(Args args) {
         args.set(1, 0f);

--- a/src/main/java/org/polyfrost/chatting/mixin/GuiNewChatMixin_Movable.java
+++ b/src/main/java/org/polyfrost/chatting/mixin/GuiNewChatMixin_Movable.java
@@ -20,7 +20,6 @@ import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
 @Mixin(GuiNewChat.class)
 public abstract class GuiNewChatMixin_Movable {
-
     @Shadow public abstract int getChatWidth();
 
     @Unique private static ChatLine chatting$currentLine;

--- a/src/main/java/org/polyfrost/chatting/mixin/GuiTextFieldMixin.java
+++ b/src/main/java/org/polyfrost/chatting/mixin/GuiTextFieldMixin.java
@@ -1,18 +1,25 @@
 package org.polyfrost.chatting.mixin;
 
+import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiTextField;
 import org.polyfrost.chatting.chat.ChatHooks;
-import org.polyfrost.chatting.config.ChattingConfig;
+import org.polyfrost.chatting.hook.GuiTextFieldHook;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(GuiTextField.class)
 public abstract class GuiTextFieldMixin {
-
     @ModifyVariable(method = "drawTextBox", at = @At(value = "STORE"), ordinal = 5)
     private int getRight(int right) {
         if (ChatHooks.INSTANCE.checkField(this)) ChatHooks.INSTANCE.setInputRight(right);
         return right;
+    }
+
+    // TODO: this method is called 3 times, here I'm targetting them all but I'm not really sure if that's required
+    @Redirect(method = "drawTextBox", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;drawStringWithShadow(Ljava/lang/String;FFI)I"))
+    private int drawStringWithShadow(FontRenderer fontRenderer, String text, float x, float y, int color) {
+        return GuiTextFieldHook.redirectDrawString(text, x, y, color);
     }
 }

--- a/src/main/java/org/polyfrost/chatting/mixin/HUDUtilsMixin.java
+++ b/src/main/java/org/polyfrost/chatting/mixin/HUDUtilsMixin.java
@@ -17,7 +17,6 @@ import java.lang.reflect.Field;
 
 @Mixin(value = HUDUtils.class, remap = false)
 public class HUDUtilsMixin {
-
     @Inject(method = "addHudOptions", at = @At("TAIL"))
     private static void hudUtils$modifyOptions(OptionPage page, Field field, Object instance, Config config, CallbackInfo ci) {
         Hud hud = (Hud) ConfigUtils.getField(field, instance);
@@ -27,6 +26,7 @@ public class HUDUtilsMixin {
         ConfigUtils.getSubCategory(page, hudAnnotation.category(), hudAnnotation.subcategory()).options.removeIf(HUDUtilsMixin::hudUtils$shouldRemove);
     }
 
+    @Unique
     private static boolean hudUtils$shouldRemove(BasicOption option) {
         String fieldName = option.getField().getName();
         Object hud = option.getParent();

--- a/src/main/kotlin/org/polyfrost/chatting/chat/ChatInputBox.kt
+++ b/src/main/kotlin/org/polyfrost/chatting/chat/ChatInputBox.kt
@@ -1,5 +1,6 @@
 package org.polyfrost.chatting.chat
 
+import cc.polyfrost.oneconfig.config.annotations.Dropdown
 import cc.polyfrost.oneconfig.config.annotations.Switch
 import cc.polyfrost.oneconfig.hud.BasicHud
 import cc.polyfrost.oneconfig.libs.universal.UMatrixStack
@@ -8,7 +9,6 @@ import net.minecraft.client.renderer.GlStateManager
 import org.polyfrost.chatting.utils.ModCompatHooks
 
 class ChatInputBox: BasicHud(true, -100f, -100f) {
-
     init {
         scale = 1f
         paddingX = 0f
@@ -26,6 +26,12 @@ class ChatInputBox: BasicHud(true, -100f, -100f) {
         description = "Drafts the text you wrote in the input field after closing the chat and backs it up when opening the chat again."
     )
     var inputFieldDraft = false
+
+    @Dropdown(
+        name = "Input Text Render Type", options = ["No Shadow", "Shadow", "Full Shadow"],
+        description = "The type of shadow to render in the input field."
+    )
+    var inputTextRenderType = 1
 
     fun drawBG(x: Float, y: Float, width: Float, height: Float) {
         if (!ModCompatHooks.shouldDrawInputBox) return


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
As title states. Currently shadow and no shadow works, but full shadow does not and I'm not sure why.

Also mixin needs a second look over prolly. See TODO

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
<!-- Provide steps to test this PR -->
turn option on

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Add text shadow options to the chat input box
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->