### PR TITLE
Searching: Wrap drawnChatLines in a new list to access messages thread-safely

### DIFF
--- a/src/main/kotlin/org/polyfrost/chatting/chat/ChatSearchingManager.kt
+++ b/src/main/kotlin/org/polyfrost/chatting/chat/ChatSearchingManager.kt
@@ -32,11 +32,12 @@ object ChatSearchingManager {
 
     @JvmStatic
     fun filterMessages(text: String, list: List<ChatLine>): List<ChatLine>? {
+        val safeList = ArrayList(list)
         val chatTabMessages = filterChatTabMessages(lastSearch)
         if (chatTabMessages != null) {
             return chatTabMessages
         }
-        return filterMessages2(text, list)
+        return filterMessages2(text, safeList)
     }
 
     @JvmStatic

--- a/src/main/kotlin/org/polyfrost/chatting/command/ChattingCommand.kt
+++ b/src/main/kotlin/org/polyfrost/chatting/command/ChattingCommand.kt
@@ -1,36 +1,14 @@
 package org.polyfrost.chatting.command
 
-import cc.polyfrost.oneconfig.libs.universal.UChat
 import cc.polyfrost.oneconfig.utils.commands.annotations.Command
 import cc.polyfrost.oneconfig.utils.commands.annotations.Main
-import cc.polyfrost.oneconfig.utils.commands.annotations.SubCommand
 import org.polyfrost.chatting.Chatting
 import org.polyfrost.chatting.config.ChattingConfig
-import kotlin.concurrent.thread
 
 @Command(value = Chatting.ID, description = "Access the " + Chatting.NAME + " GUI.")
 class ChattingCommand {
     @Main
     fun main() {
         ChattingConfig.openGui()
-    }
-
-    @SubCommand
-    fun loop(amt: Int) {
-        thread {
-            for (i in 1..amt) {
-                UChat.chat(i)
-            }
-        }
-    }
-
-    @SubCommand
-    fun loopDelay(amt: Int, delay: Int) {
-        thread {
-            for (i in 1..amt) {
-                UChat.chat(i)
-                Thread.sleep(delay.toLong())
-            }
-        }
     }
 }

--- a/src/main/kotlin/org/polyfrost/chatting/command/ChattingCommand.kt
+++ b/src/main/kotlin/org/polyfrost/chatting/command/ChattingCommand.kt
@@ -1,14 +1,36 @@
 package org.polyfrost.chatting.command
 
+import cc.polyfrost.oneconfig.libs.universal.UChat
 import cc.polyfrost.oneconfig.utils.commands.annotations.Command
 import cc.polyfrost.oneconfig.utils.commands.annotations.Main
+import cc.polyfrost.oneconfig.utils.commands.annotations.SubCommand
 import org.polyfrost.chatting.Chatting
 import org.polyfrost.chatting.config.ChattingConfig
+import kotlin.concurrent.thread
 
 @Command(value = Chatting.ID, description = "Access the " + Chatting.NAME + " GUI.")
 class ChattingCommand {
     @Main
     fun main() {
         ChattingConfig.openGui()
+    }
+
+    @SubCommand
+    fun loop(amt: Int) {
+        thread {
+            for (i in 1..amt) {
+                UChat.chat(i)
+            }
+        }
+    }
+
+    @SubCommand
+    fun loopDelay(amt: Int, delay: Int) {
+        thread {
+            for (i in 1..amt) {
+                UChat.chat(i)
+                Thread.sleep(delay.toLong())
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Searching: Wrap drawnChatLines in a new list to access messages thread-safely
`<GuiNewChat>.drawnChatLines` -> `new ArrayList(<GuiNewChat>.drawnChatLines)`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Fixes #47 

## How to test
<!-- Provide steps to test this PR -->

open the chat search bar
send chat messages from a different thread
it should no longer crash!

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
```

Fix crash with searching messages 

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

No