### PR TITLE
fix: align chat buttons properly

### DIFF
--- a/src/main/java/org/polyfrost/chatting/chat/ChatButtons.java
+++ b/src/main/java/org/polyfrost/chatting/chat/ChatButtons.java
@@ -6,6 +6,29 @@ public final class ChatButtons {
 
     public static final int BUTTON_WIDTH = 9;
 
+    /** Horizontal gap, in chat-local pixels, between adjacent per-line buttons. */
+    public static final int BUTTON_GAP = 1;
+
+    /**
+     * Padding, in chat-local pixels, that the vanilla message background extends past the message
+     * text on the right side (the {@code + 4 + 4} in {@code ChatComponent}'s background fill).
+     */
+    public static final int BACKGROUND_RIGHT_PADDING = 8;
+
+    /**
+     * The {@code pose.translate(4, 0)} that {@code ChatComponent#render} applies (inside the chat
+     * scale) before drawing messages. The per-line buttons are drawn without that translate, so it
+     * has to be added to line them up with the background's right edge.
+     */
+    public static final int TEXT_LEFT_OFFSET = 4;
+
+    /**
+     * Offset, in chat-local pixels, from the message text width to the right edge of the message
+     * background. The per-line buttons start here so they sit just outside the background when it is
+     * not being extended.
+     */
+    public static final int BACKGROUND_RIGHT_EDGE = TEXT_LEFT_OFFSET + BACKGROUND_RIGHT_PADDING;
+
     private ChatButtons() {
     }
 
@@ -20,8 +43,15 @@ public final class ChatButtons {
         return perLineButtonCount() > 0;
     }
 
+    /** Total width, in chat-local pixels, occupied by the per-line button strip. */
+    public static int perLineButtonsWidth() {
+        int count = perLineButtonCount();
+        if (count == 0) return 0;
+        return count * BUTTON_WIDTH + (count - 1) * BUTTON_GAP;
+    }
+
     public static int extraBackgroundWidth() {
         if (!ChattingConfig.INSTANCE.getExtendBG()) return 0;
-        return perLineButtonCount() * BUTTON_WIDTH;
+        return perLineButtonsWidth();
     }
 }

--- a/src/main/java/org/polyfrost/chatting/mixin/ChatScreenMixin.java
+++ b/src/main/java/org/polyfrost/chatting/mixin/ChatScreenMixin.java
@@ -179,7 +179,9 @@ public abstract class ChatScreenMixin extends Screen {
         if (!perLine) return;
 
         int lineHeight = acc.chatting$getLineHeight();
-        int localRight = (int) (acc.chatting$getWidth() / chatScale);
+        // Anchor the buttons at the message background's right edge (text width + the background's
+        // right edge offset) so they sit just outside it when "Extend Chat Backgrounds" is disabled.
+        int stripStart = (int) Math.ceil(acc.chatting$getWidth() / chatScale) + ChatButtons.BACKGROUND_RIGHT_EDGE;
         int top = chatting$chatBottomLocal(chatScale) - (lineIndex + 1) * lineHeight
                 + (int) Math.ceil((lineHeight - 9) / 2.0);
 
@@ -205,12 +207,12 @@ public abstract class ChatScreenMixin extends Screen {
 
         int slot = 0;
         if (cfg.getChatCopy()) {
-            chatting$button(graphics, Textures.COPY, localRight + 2 + slot * (ChatButtons.BUTTON_WIDTH + 1), top,
+            chatting$button(graphics, Textures.COPY, stripStart + slot * (ChatButtons.BUTTON_WIDTH + ChatButtons.BUTTON_GAP), top,
                     chatScale, mx, my, CHATTING$COPY_TOOLTIP, () -> chatting$copyAction(acc, messageIndex, lineIndex));
             slot++;
         }
         if (cfg.getChatDelete()) {
-            chatting$button(graphics, Textures.DELETE, localRight + 2 + slot * (ChatButtons.BUTTON_WIDTH + 1), top,
+            chatting$button(graphics, Textures.DELETE, stripStart + slot * (ChatButtons.BUTTON_WIDTH + ChatButtons.BUTTON_GAP), top,
                     chatScale, mx, my, CHATTING$DELETE_TOOLTIP, () -> chatting$deleteAction(acc, lineIndex));
         }
 


### PR DESCRIPTION
## Description
Fixes Copy and Delete buttons being slightly misaligned from their expected position. It seemed to me like it was slightly off both with and without Extend Chat Background, so I adjusted both:
- On: The buttons are inside the extended chat background, directly at the end.
- Off: The buttons are directly next to the vanilla chat background.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes part of #101

## How to test
1. Launch the game
2. Join a world
3. Send some chat messages
4. Hover over some messages and observe the position of the Copy/Delete buttons
5. Toggle the Extend Chat Background option and repeat Step 4

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Fixed Copy and Delete buttons being misaligned
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->