### PR TITLE
fix: highlight only one chat line when hovering between lines

### DIFF
--- a/src/main/java/org/polyfrost/chatting/mixin/ChatScreenMixin.java
+++ b/src/main/java/org/polyfrost/chatting/mixin/ChatScreenMixin.java
@@ -443,7 +443,10 @@ public abstract class ChatScreenMixin extends Screen {
         return (int) acc.chatting$screenToChatY(mouseY);
         //?} else {
         /*double d = (double) this.minecraft.getWindow().getGuiScaledHeight() - mouseY - 40.0;
-        return (int) (d / (acc.chatting$getScale() * acc.chatting$getLineHeight()));
+        // Match FocusedAccessMixin's half-open [entryTop, entryBottom) hover test: exactly on the
+        // boundary between two lines the cursor pixel belongs to the lower line (ceil - 1 instead of
+        // floor), so the highlighted line and the line the buttons target always agree.
+        return (int) Math.ceil(d / (acc.chatting$getScale() * acc.chatting$getLineHeight())) - 1;
         *///?}
     }
 

--- a/src/main/java/org/polyfrost/chatting/mixin/FocusedAccessMixin.java
+++ b/src/main/java/org/polyfrost/chatting/mixin/FocusedAccessMixin.java
@@ -39,7 +39,7 @@ public class FocusedAccessMixin {
     @Unique
     private int chatting$hoverColor(org.joml.Matrix3x2fStack pose, int x1, int y1, int x2, int y2, int color) {
         Vector2f m = pose.invert(new Matrix3x2f()).transformPosition(chatting$mouseX, chatting$mouseY, new Vector2f());
-        if (m.x >= x1 && m.x <= x2 && m.y >= y1 && m.y <= y2) {
+        if (m.x >= x1 && m.x < x2 && m.y >= y1 && m.y < y2) {
             return ChattingConfig.INSTANCE.getHoveredChatBackgroundColor().getArgb();
         }
         return color;
@@ -60,7 +60,7 @@ public class FocusedAccessMixin {
     @Unique
     private int chatting$hoverColor(org.joml.Matrix3x2fStack pose, int x1, int y1, int x2, int y2, int color) {
         Vector2f m = pose.invert(new Matrix3x2f()).transformPosition(chatting$mouseX, chatting$mouseY, new Vector2f());
-        if (m.x >= x1 && m.x <= x2 && m.y >= y1 && m.y <= y2) {
+        if (m.x >= x1 && m.x < x2 && m.y >= y1 && m.y < y2) {
             return ChattingConfig.INSTANCE.getHoveredChatBackgroundColor().getArgb();
         }
         return color;


### PR DESCRIPTION
## Description
When hovering at an edge between two chat messages, the mod would previously highlight both of them. This change ensures only one of them is highlighted and the highlighted message is always the one that gets the Copy/Delete buttons.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes part of #101

## How to test
1. Launch the game
2. Join a world
3. Send some chat messages
4. Hover over the messages, testing both clear and ambiguous in-between-messages states
5. Ensure there's always a single message highlighted that seems right for where the cursor is, and the buttons show up on the same message

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Fixed both messages being highlighted if mouse is on the edge between two messages
Fixed the Copy/Delete buttons sometimes being on a different message from the one that is highlighted
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->